### PR TITLE
Adapt absolute base path to any user

### DIFF
--- a/natural/src/dataloaders.py
+++ b/natural/src/dataloaders.py
@@ -9,14 +9,14 @@ import os
 import warnings
 import logging
 import socket
-
+from pathlib import Path
 
 class DataLoaders:
     def __init__(self, dataset_name, batch_size_train, batch_size_test, dim_image=128, train=False):
         self.dataset_name = dataset_name
         self.batch_size_train = batch_size_train
         self.batch_size_test = batch_size_test
-        self.base_path = os.path.join('/home/user/work/PycharmProjects/Restora-Flow')
+        self.base_path = Path(__file__).resolve().parent.parent.parent
         self.dim_image = dim_image
         self.train = train
 


### PR DESCRIPTION
This PR changes the line
`self.base_path = os.path.join('/home/user/work/PycharmProjects/Restora-Flow')`
in `natural/src/dataloader.py` so that it correctly reads the absolute path to the project for _any_ user. It uses the `pathlib` built-in Python 3.4+ library.